### PR TITLE
Add button to sandbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,13 @@
 
 				<p>The <a href="https://gateway.metagov.org" target="_blank">Metagov Gateway</a> is an open-source API gateway for online communities. It helps communities govern themselves by connecting decision-making tools to platforms where decisions need to be made.
 				</p>
+				<div>
+					<a href="https://sandbox.metagov.org" class="btn">Sandbox</a>
+				</div>
 				<p>Currently supports Slack, Discord, Discourse, GitHub, <a href="https://docs.metagov.org/en/latest/readme.html">and more</a>.
 				</p>
-
 				<div>
-					<button data-tf-popup="TJsqo8CG" class="btn primary">Join the beta</button><script src="//embed.typeform.com/next/embed.js"></script>
+					<button data-tf-popup="TJsqo8CG" class="btn primary">Connect with us</button><script src="//embed.typeform.com/next/embed.js"></script>
 
 					<a href="https://docs.metagov.org" class="btn">Docs</a>
 				</div>


### PR DESCRIPTION
Sandbox button links to https://sandbox.metagov.org. This should point to home.html in the recent PR for the Gateway Sandbox fork of PolicyKit. See: https://github.com/metagov/gateway-sandbox/pull/1